### PR TITLE
Add a Validity parameter to ShortMessage struct.

### DIFF
--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -6,6 +6,7 @@ package smpp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
@@ -44,6 +45,7 @@ func TestShortMessage(t *testing.T) {
 		Src:      "root",
 		Dst:      "foobar",
 		Text:     pdutext.Raw("Lorem ipsum"),
+		Validity: 10 * time.Minute,
 		Register: NoDeliveryReceipt,
 	})
 	if err != nil {


### PR DESCRIPTION
Validity paramter specifies the validity of the message after
submission to the SMSC, absolute time format is used.