### PR TITLE
Seeding rand in transceiver so it won't cause panic

### DIFF
--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -7,10 +7,10 @@ package smpp
 import (
 	"crypto/tls"
 	"fmt"
-	"time"
-
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"math/rand"
+	"time"
 )
 
 // Transceiver implements an SMPP transceiver.
@@ -31,6 +31,7 @@ type Transceiver struct {
 
 // Bind implements the ClientConn interface.
 func (t *Transceiver) Bind() <-chan ConnStatus {
+	t.r = rand.New(rand.NewSource(time.Now().UnixNano()))
 	t.conn.Lock()
 	defer t.conn.Unlock()
 	if t.conn.client != nil {


### PR DESCRIPTION
Transceiver's Bind function was missing `t.r = rand.New(rand.NewSource(time.Now().UnixNano()))`. Added now.