### PR TITLE
BroadcastMessage() function to send to all receivers

### DIFF
--- a/smpp/receiver_test.go
+++ b/smpp/receiver_test.go
@@ -31,9 +31,7 @@ func TestReceiver(t *testing.T) {
 	}
 	// cheat: inject GenericNACK PDU for the server to echo back.
 	p := pdu.NewGenericNACK()
-	r.conn.Lock()
-	r.conn.Write(p)
-	r.conn.Unlock()
+	s.BroadcastMessage(p)
 	// check response.
 	select {
 	case m := <-rc:
@@ -45,4 +43,9 @@ func TestReceiver(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for server to echo")
 	}
+}
+
+func TestReceiver_Broadcast(t *testing.T) {
+
+
 }

--- a/smpp/receiver_test.go
+++ b/smpp/receiver_test.go
@@ -44,8 +44,3 @@ func TestReceiver(t *testing.T) {
 		t.Fatal("timeout waiting for server to echo")
 	}
 }
-
-func TestReceiver_Broadcast(t *testing.T) {
-
-
-}

--- a/smpp/receiver_test.go
+++ b/smpp/receiver_test.go
@@ -29,7 +29,7 @@ func TestReceiver(t *testing.T) {
 	default:
 		t.Fatal(conn.Error())
 	}
-	// cheat: inject GenericNACK PDU for the server to echo back.
+	// trigger inbound message from server
 	p := pdu.NewGenericNACK()
 	s.BroadcastMessage(p)
 	// check response.


### PR DESCRIPTION
I found the smpptest server extremely useful for testing transmitters but not so helpful for testing receivers. In the `receiver_test` for example, receipt of a message is achieved by hijacking the `Receiver.conn`, rather than coming from the actual test server.

So I've added a `BroadcastMessage` function to write a given test message to all bound receiver connections. 