### PR TITLE
Fix crash when disconnect happens while submitting a message. Fixes #32

### DIFF
--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -302,6 +302,9 @@ func (t *Transmitter) do(p pdu.Body) (*tx, error) {
 	}
 	select {
 	case resp := <-rc:
+		if resp.Err != nil {
+			return nil, resp.Err
+		}
 		return resp, nil
 	case <-t.conn.respTimeout():
 		return nil, errors.New("timeout waiting for response")


### PR DESCRIPTION
The added test case does not cover fully the crash I experience since it happens after writing to the socket started already, bit tricky to add a test case for that.