### PR TITLE
features and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: go
 go:
-        - 1.7
-        - tip
+        - 1.5
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover
-        - go get golang.org/x/time/rate
 script:
         - go test -v -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ go:
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover
+        - go get golang.org/x/time/rate
 script:
         - go test -v -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
         - 1.5
+        - 1.6
+        - 1.7
+        - tip
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
         - 1.7
+        - tip
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ go:
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover
+        - go get golang.org/x/time/rate
 script:
         - go test -v -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 go:
-        - 1.5
+        - 1.7
 install:
         - go get -d -v ./...
         - go get -d -v golang.org/x/tools/cmd/cover
 script:
         - go test -v -cover ./...
-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,5 @@
 
 Nevio <0x19@users.noreply.github.com>
 Valério Valério <valerio.valerio@comptel.com>
+Ilya Danilkin <nezorflame@gmail.com>
+Igor Novgorodov <igor@novg.net>

--- a/cmd/sms/main.go
+++ b/cmd/sms/main.go
@@ -202,7 +202,12 @@ var cmdQueryMessage = cli.Command{
 		log.Println("Connected to", tx.Addr)
 		sender, msgid := c.Args()[0], c.Args()[1]
 		log.Printf("Command: query %q %q", sender, msgid)
-		qr, err := tx.QuerySM(sender, msgid)
+		qr, err := tx.QuerySM(
+			sender,
+			msgid,
+			uint8(c.Int("source-addr-ton")),
+			uint8(c.Int("source-addr-npi")),
+		)
 		if err != nil {
 			log.Fatalln("Failed:", err)
 		}

--- a/cmd/sms/main.go
+++ b/cmd/sms/main.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 
 	"github.com/fiorix/go-smpp/smpp"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"

--- a/cmd/sms/main.go
+++ b/cmd/sms/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/codegangsta/cli"
 
 	"github.com/fiorix/go-smpp/smpp"
+	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
 )
 
@@ -150,9 +151,9 @@ var cmdShortMessage = cli.Command{
 		recipient := c.Args()[1]
 		text := strings.Join(c.Args()[2:], " ")
 		log.Printf("Command: send %q %q %q", sender, recipient, text)
-		var register smpp.DeliverySetting
+		var register pdufield.DeliverySetting
 		if c.Bool("register") {
-			register = smpp.FinalDeliveryReceipt
+			register = pdufield.FinalDeliveryReceipt
 		}
 		var codec pdutext.Codec
 		switch c.String("encoding") {

--- a/smpp/client.go
+++ b/smpp/client.go
@@ -67,7 +67,7 @@ type ClientConn interface {
 	Closer
 }
 
-// RateLimiter is defines an interface for pacing the sending
+// RateLimiter defines an interface for pacing the sending
 // of short messages to a client connection.
 //
 // The Transmitter or Transceiver using the RateLimiter holds a

--- a/smpp/client.go
+++ b/smpp/client.go
@@ -5,12 +5,13 @@
 package smpp
 
 import (
-	"context"
 	"crypto/tls"
 	"io"
 	"math"
 	"sync"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"

--- a/smpp/client.go
+++ b/smpp/client.go
@@ -159,8 +159,12 @@ func (c *client) Bind() {
 	retry:
 		close(eli)
 		c.conn.Close()
-		delay = math.Min(delay*math.E, maxdelay)
-		c.trysleep(time.Duration(delay) * time.Second)
+		delayDuration := c.BindInterval
+		if delayDuration == 0 {
+			delay = math.Min(delay*math.E, maxdelay)
+			delayDuration = time.Duration(delay) * time.Second
+		}
+		c.trysleep(delayDuration)
 	}
 	close(c.Status)
 }

--- a/smpp/client.go
+++ b/smpp/client.go
@@ -74,7 +74,7 @@ type ClientConn interface {
 // single context.Context per client connection, passed to Wait
 // prior to sending short messages.
 //
-// Suitable for use with package github.com/golang/time/rate.
+// Suitable for use with package golang.org/x/time/rate.
 type RateLimiter interface {
 	// Wait blocks until the limiter permits an event to happen.
 	Wait(ctx context.Context) error

--- a/smpp/example_test.go
+++ b/smpp/example_test.go
@@ -100,7 +100,7 @@ func ExampleTransceiver() {
 			Src:      r.FormValue("src"),
 			Dst:      r.FormValue("dst"),
 			Text:     pdutext.Raw(r.FormValue("text")),
-			Register: smpp.FinalDeliveryReceipt,
+			Register: pdufield.FinalDeliveryReceipt,
 		})
 		if err == smpp.ErrNotConnected {
 			http.Error(w, "Oops.", http.StatusServiceUnavailable)

--- a/smpp/example_test.go
+++ b/smpp/example_test.go
@@ -60,7 +60,7 @@ func ExampleTransmitter() {
 		Src:      "sender",
 		Dst:      "recipient",
 		Text:     pdutext.Latin1("Olá mundo"),
-		Register: smpp.NoDeliveryReceipt,
+		Register: pdufield.NoDeliveryReceipt,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/smpp/example_test.go
+++ b/smpp/example_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang/time/rate"
+
 	"github.com/fiorix/go-smpp/smpp"
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
@@ -34,8 +36,10 @@ func ExampleReceiver() {
 		Passwd:  "secret",
 		Handler: f,
 	}
-	conn := r.Bind() // make persistent connection.
+	// Create persistent connection.
+	conn := r.Bind()
 	time.AfterFunc(10*time.Second, func() { r.Close() })
+	// Print connection status (Connected, Disconnected, etc).
 	for c := range conn {
 		log.Println("SMPP connection status:", c.Status())
 	}
@@ -47,22 +51,21 @@ func ExampleTransmitter() {
 		User:   "foobar",
 		Passwd: "secret",
 	}
-	conn := <-tx.Bind() // make persistent connection.
-	switch conn.Status() {
-	case smpp.Connected:
-		sm, err := tx.Submit(&smpp.ShortMessage{
-			Src:      "sender",
-			Dst:      "recipient",
-			Text:     pdutext.Latin1("Olá mundo"),
-			Register: smpp.NoDeliveryReceipt,
-		})
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Println("Message ID:", sm.RespID())
-	default:
+	// Create persistent connection, wait for the first status.
+	conn := <-tx.Bind()
+	if conn.Status() != smpp.Connected {
 		log.Fatal(conn.Error())
 	}
+	sm, err := tx.Submit(&smpp.ShortMessage{
+		Src:      "sender",
+		Dst:      "recipient",
+		Text:     pdutext.Latin1("Olá mundo"),
+		Register: smpp.NoDeliveryReceipt,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("Message ID:", sm.RespID())
 }
 
 func ExampleTransceiver() {
@@ -77,13 +80,16 @@ func ExampleTransceiver() {
 				src, dst, txt)
 		}
 	}
+	lm := rate.NewLimiter(rate.Limit(10), 1) // Max rate of 10/s.
 	tx := &smpp.Transceiver{
-		Addr:    "localhost:2775",
-		User:    "foobar",
-		Passwd:  "secret",
-		Handler: f,
+		Addr:        "localhost:2775",
+		User:        "foobar",
+		Passwd:      "secret",
+		Handler:     f,  // Handle incoming SM or delivery receipts.
+		RateLimiter: lm, // Optional rate limiter.
 	}
-	conn := tx.Bind() // make persistent connection.
+	// Create persistent connection.
+	conn := tx.Bind()
 	go func() {
 		for c := range conn {
 			log.Println("SMPP connection status:", c.Status())

--- a/smpp/example_test.go
+++ b/smpp/example_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/time/rate"
+	"golang.org/x/time/rate"
 
 	"github.com/fiorix/go-smpp/smpp"
 	"github.com/fiorix/go-smpp/smpp/pdu"

--- a/smpp/pdu/pdufield/map.go
+++ b/smpp/pdu/pdufield/map.go
@@ -32,6 +32,8 @@ func (m Map) Set(k Name, v interface{}) error {
 		m[k] = New(k, []byte(v.(string)))
 	case []byte:
 		m[k] = New(k, []byte(v.([]byte)))
+	case DeliverySetting:
+		m[k] = New(k, []byte{uint8(v.(DeliverySetting))})
 	case Body:
 		m[k] = v.(Body)
 	case pdutext.Codec:

--- a/smpp/pdu/pdufield/types.go
+++ b/smpp/pdu/pdufield/types.go
@@ -149,6 +149,17 @@ func (sm *SM) SerializeTo(w io.Writer) error {
 	return err
 }
 
+// DeliverySetting is used to configure registered delivery
+// for short messages.
+type DeliverySetting uint8
+
+// Supported delivery settings.
+const (
+	NoDeliveryReceipt      DeliverySetting = 0x00
+	FinalDeliveryReceipt   DeliverySetting = 0x01
+	FailureDeliveryReceipt DeliverySetting = 0x02
+)
+
 // DestSme is a PDU field used for an sme addreses.
 type DestSme struct {
 	Flag     Fixed

--- a/smpp/receiver.go
+++ b/smpp/receiver.go
@@ -22,6 +22,7 @@ type Receiver struct {
 	SystemType         string
 	EnquireLink        time.Duration
 	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
+	BindInterval       time.Duration // Binding retry interval
 	TLS                *tls.Config
 	Handler            HandlerFunc
 
@@ -53,6 +54,7 @@ func (r *Receiver) Bind() <-chan ConnStatus {
 		EnquireLinkTimeout: r.EnquireLinkTimeout,
 		Status:             make(chan ConnStatus, 1),
 		BindFunc:           r.bindFunc,
+		BindInterval:       r.BindInterval,
 	}
 	r.conn.client = c
 	c.init()

--- a/smpp/receiver.go
+++ b/smpp/receiver.go
@@ -16,13 +16,14 @@ import (
 
 // Receiver implements an SMPP client receiver.
 type Receiver struct {
-	Addr        string
-	User        string
-	Passwd      string
-	SystemType  string
-	EnquireLink time.Duration
-	TLS         *tls.Config
-	Handler     HandlerFunc
+	Addr               string
+	User               string
+	Passwd             string
+	SystemType         string
+	EnquireLink        time.Duration
+	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
+	TLS                *tls.Config
+	Handler            HandlerFunc
 
 	conn struct {
 		sync.Mutex
@@ -46,11 +47,12 @@ func (r *Receiver) Bind() <-chan ConnStatus {
 		return r.conn.Status
 	}
 	c := &client{
-		Addr:        r.Addr,
-		TLS:         r.TLS,
-		EnquireLink: r.EnquireLink,
-		Status:      make(chan ConnStatus, 1),
-		BindFunc:    r.bindFunc,
+		Addr:               r.Addr,
+		TLS:                r.TLS,
+		EnquireLink:        r.EnquireLink,
+		EnquireLinkTimeout: r.EnquireLinkTimeout,
+		Status:             make(chan ConnStatus, 1),
+		BindFunc:           r.bindFunc,
 	}
 	r.conn.client = c
 	c.init()

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -18,15 +18,16 @@ import (
 //
 // The API is a combination of the Transmitter and Receiver.
 type Transceiver struct {
-	Addr        string
-	User        string
-	Passwd      string
-	SystemType  string
-	EnquireLink time.Duration
-	RespTimeout time.Duration
-	TLS         *tls.Config
+	Addr        string        // Server address in form of host:port.
+	User        string        // Username.
+	Passwd      string        // Password.
+	SystemType  string        // System type, default empty.
+	EnquireLink time.Duration // Enquire link interval, default 10s.
+	RespTimeout time.Duration // Response timeout, default 1s.
+	TLS         *tls.Config   // TLS client settings, optional.
+	Handler     HandlerFunc   // Receiver handler, optional.
+	RateLimiter RateLimiter   // Rate limiter, optional.
 	WindowSize  uint
-	Handler     HandlerFunc
 
 	Transmitter
 }
@@ -45,11 +46,12 @@ func (t *Transceiver) Bind() <-chan ConnStatus {
 	c := &client{
 		Addr:        t.Addr,
 		TLS:         t.TLS,
-		EnquireLink: t.EnquireLink,
-		RespTimeout: t.RespTimeout,
 		Status:      make(chan ConnStatus, 1),
 		BindFunc:    t.bindFunc,
+		EnquireLink: t.EnquireLink,
+		RespTimeout: t.RespTimeout,
 		WindowSize:  t.WindowSize,
+		RateLimiter: t.RateLimiter,
 	}
 	t.conn.client = c
 	c.init()

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -25,6 +25,7 @@ type Transceiver struct {
 	EnquireLink        time.Duration // Enquire link interval, default 10s.
 	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
 	RespTimeout        time.Duration // Response timeout, default 1s.
+	BindInterval       time.Duration // Binding retry interval
 	TLS                *tls.Config   // TLS client settings, optional.
 	Handler            HandlerFunc   // Receiver handler, optional.
 	RateLimiter        RateLimiter   // Rate limiter, optional.
@@ -54,6 +55,7 @@ func (t *Transceiver) Bind() <-chan ConnStatus {
 		RespTimeout:        t.RespTimeout,
 		WindowSize:         t.WindowSize,
 		RateLimiter:        t.RateLimiter,
+		BindInterval:       t.BindInterval,
 	}
 	t.conn.client = c
 	c.init()

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -18,16 +18,17 @@ import (
 //
 // The API is a combination of the Transmitter and Receiver.
 type Transceiver struct {
-	Addr        string        // Server address in form of host:port.
-	User        string        // Username.
-	Passwd      string        // Password.
-	SystemType  string        // System type, default empty.
-	EnquireLink time.Duration // Enquire link interval, default 10s.
-	RespTimeout time.Duration // Response timeout, default 1s.
-	TLS         *tls.Config   // TLS client settings, optional.
-	Handler     HandlerFunc   // Receiver handler, optional.
-	RateLimiter RateLimiter   // Rate limiter, optional.
-	WindowSize  uint
+	Addr               string        // Server address in form of host:port.
+	User               string        // Username.
+	Passwd             string        // Password.
+	SystemType         string        // System type, default empty.
+	EnquireLink        time.Duration // Enquire link interval, default 10s.
+	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
+	RespTimeout        time.Duration // Response timeout, default 1s.
+	TLS                *tls.Config   // TLS client settings, optional.
+	Handler            HandlerFunc   // Receiver handler, optional.
+	RateLimiter        RateLimiter   // Rate limiter, optional.
+	WindowSize         uint
 
 	Transmitter
 }
@@ -44,14 +45,15 @@ func (t *Transceiver) Bind() <-chan ConnStatus {
 	t.tx.inflight = make(map[uint32]chan *tx)
 	t.tx.Unlock()
 	c := &client{
-		Addr:        t.Addr,
-		TLS:         t.TLS,
-		Status:      make(chan ConnStatus, 1),
-		BindFunc:    t.bindFunc,
-		EnquireLink: t.EnquireLink,
-		RespTimeout: t.RespTimeout,
-		WindowSize:  t.WindowSize,
-		RateLimiter: t.RateLimiter,
+		Addr:               t.Addr,
+		TLS:                t.TLS,
+		Status:             make(chan ConnStatus, 1),
+		BindFunc:           t.bindFunc,
+		EnquireLink:        t.EnquireLink,
+		EnquireLinkTimeout: t.EnquireLinkTimeout,
+		RespTimeout:        t.RespTimeout,
+		WindowSize:         t.WindowSize,
+		RateLimiter:        t.RateLimiter,
 	}
 	t.conn.client = c
 	c.init()

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -37,10 +37,10 @@ type Transceiver struct {
 // Bind implements the ClientConn interface.
 func (t *Transceiver) Bind() <-chan ConnStatus {
 	t.r = rand.New(rand.NewSource(time.Now().UnixNano()))
-	t.conn.Lock()
-	defer t.conn.Unlock()
-	if t.conn.client != nil {
-		return t.conn.Status
+	t.cl.Lock()
+	defer t.cl.Unlock()
+	if t.cl.client != nil {
+		return t.cl.Status
 	}
 	t.tx.Lock()
 	t.tx.inflight = make(map[uint32]chan *tx)
@@ -57,7 +57,7 @@ func (t *Transceiver) Bind() <-chan ConnStatus {
 		RateLimiter:        t.RateLimiter,
 		BindInterval:       t.BindInterval,
 	}
-	t.conn.client = c
+	t.cl.client = c
 	c.init()
 	go c.Bind()
 	return c.Status

--- a/smpp/transceiver_test.go
+++ b/smpp/transceiver_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/time/rate"
+	"golang.org/x/time/rate"
 
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"

--- a/smpp/transceiver_test.go
+++ b/smpp/transceiver_test.go
@@ -68,7 +68,7 @@ func TestTransceiver(t *testing.T) {
 		Src:      "root",
 		Dst:      "foobar",
 		Text:     pdutext.Raw("Lorem ipsum"),
-		Register: FinalDeliveryReceipt,
+		Register: pdufield.FinalDeliveryReceipt,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/smpp/transceiver_test.go
+++ b/smpp/transceiver_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/time/rate"
+
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
@@ -49,10 +51,11 @@ func TestTransceiver(t *testing.T) {
 		}
 	}
 	tc := &Transceiver{
-		Addr:    s.Addr(),
-		User:    smpptest.DefaultUser,
-		Passwd:  smpptest.DefaultPasswd,
-		Handler: receiver,
+		Addr:        s.Addr(),
+		User:        smpptest.DefaultUser,
+		Passwd:      smpptest.DefaultPasswd,
+		Handler:     receiver,
+		RateLimiter: rate.NewLimiter(rate.Limit(10), 1),
 	}
 	defer tc.Close()
 	conn := <-tc.Bind()

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -37,9 +37,10 @@ type Transmitter struct {
 	EnquireLink        time.Duration // Enquire link interval, default 10s.
 	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
 	RespTimeout        time.Duration // Response timeout, default 1s.
+	BindInterval       time.Duration // Binding retry interval
+	TLS                *tls.Config   // TLS client settings, optional.
+	RateLimiter        RateLimiter   // Rate limiter, optional.
 	WindowSize         uint
-	RateLimiter        RateLimiter // Rate limiter, optional.
-	TLS                *tls.Config // TLS client settings, optional.
 	r                  *rand.Rand
 
 	conn struct {
@@ -82,6 +83,7 @@ func (t *Transmitter) Bind() <-chan ConnStatus {
 		RespTimeout:        t.RespTimeout,
 		WindowSize:         t.WindowSize,
 		RateLimiter:        t.RateLimiter,
+		BindInterval:       t.BindInterval,
 	}
 	t.conn.client = c
 	c.init()

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -30,16 +30,17 @@ const MaxDestinationAddress = 254
 
 // Transmitter implements an SMPP client transmitter.
 type Transmitter struct {
-	Addr        string        // Server address in form of host:port.
-	User        string        // Username.
-	Passwd      string        // Password.
-	SystemType  string        // System type, default empty.
-	EnquireLink time.Duration // Enquire link interval, default 10s.
-	RespTimeout time.Duration // Response timeout, default 1s.
-	WindowSize  uint
-	RateLimiter RateLimiter // Rate limiter, optional.
-	TLS         *tls.Config // TLS client settings, optional.
-	r           *rand.Rand
+	Addr               string        // Server address in form of host:port.
+	User               string        // Username.
+	Passwd             string        // Password.
+	SystemType         string        // System type, default empty.
+	EnquireLink        time.Duration // Enquire link interval, default 10s.
+	EnquireLinkTimeout time.Duration // Time after last EnquireLink response when connection considered down
+	RespTimeout        time.Duration // Response timeout, default 1s.
+	WindowSize         uint
+	RateLimiter        RateLimiter // Rate limiter, optional.
+	TLS                *tls.Config // TLS client settings, optional.
+	r                  *rand.Rand
 
 	conn struct {
 		sync.Mutex
@@ -72,14 +73,15 @@ func (t *Transmitter) Bind() <-chan ConnStatus {
 	t.tx.inflight = make(map[uint32]chan *tx)
 	t.tx.Unlock()
 	c := &client{
-		Addr:        t.Addr,
-		TLS:         t.TLS,
-		Status:      make(chan ConnStatus, 1),
-		BindFunc:    t.bindFunc,
-		EnquireLink: t.EnquireLink,
-		RespTimeout: t.RespTimeout,
-		WindowSize:  t.WindowSize,
-		RateLimiter: t.RateLimiter,
+		Addr:               t.Addr,
+		TLS:                t.TLS,
+		Status:             make(chan ConnStatus, 1),
+		BindFunc:           t.bindFunc,
+		EnquireLink:        t.EnquireLink,
+		EnquireLinkTimeout: t.EnquireLinkTimeout,
+		RespTimeout:        t.RespTimeout,
+		WindowSize:         t.WindowSize,
+		RateLimiter:        t.RateLimiter,
 	}
 	t.conn.client = c
 	c.init()

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -490,12 +490,15 @@ type QueryResp struct {
 }
 
 // QuerySM queries the delivery status of a message. It requires the
-// source address (sender) and message ID.
-func (t *Transmitter) QuerySM(src, msgid string) (*QueryResp, error) {
+// source address (sender) with TON and NPI and message ID.
+func (t *Transmitter) QuerySM(src, msgid string, srcTON, srcNPI uint8) (*QueryResp, error) {
 	p := pdu.NewQuerySM()
 	f := p.Fields()
 	f.Set(pdufield.SourceAddr, src)
+	f.Set(pdufield.SourceAddrTON, srcTON)
+	f.Set(pdufield.SourceAddrNPI, srcNPI)
 	f.Set(pdufield.MessageID, msgid)
+
 	resp, err := t.do(p)
 	if err != nil {
 		return nil, err

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -177,7 +177,7 @@ type ShortMessage struct {
 	DLs      []string //List if destribution list for submit multi
 	Text     pdutext.Codec
 	Validity time.Duration
-	Register DeliverySetting
+	Register pdufield.DeliverySetting
 
 	// Other fields, normally optional.
 	ServiceType          string

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -514,7 +514,7 @@ func (t *Transmitter) QuerySM(src, msgid string) (*QueryResp, error) {
 	qr := &QueryResp{MsgID: msgid}
 	switch ms.Bytes()[0] {
 	case 0:
-		qr.MsgState = "DELIVERED"
+		qr.MsgState = "SCHEDULED"
 	case 1:
 		qr.MsgState = "ENROUTE"
 	case 2:

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -188,7 +188,7 @@ func TestQuerySM(t *testing.T) {
 	default:
 		t.Fatal(conn.Error())
 	}
-	qr, err := tx.QuerySM("root", "13")
+	qr, err := tx.QuerySM("root", "13", uint8(5), uint8(0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func TestSubmitMulti(t *testing.T) {
 		DLs:      []string{"DistributionList1"},
 		Text:     pdutext.Raw("Lorem ipsum"),
 		Validity: 10 * time.Minute,
-		Register: NoDeliveryReceipt,
+		Register: pdufield.NoDeliveryReceipt,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -301,7 +301,7 @@ func TestNotConnected(t *testing.T) {
 		Dst:      "foobar",
 		Text:     pdutext.Raw("Lorem ipsum"),
 		Validity: 10 * time.Minute,
-		Register: NoDeliveryReceipt,
+		Register: pdufield.NoDeliveryReceipt,
 	})
 	if err != ErrNotConnected {
 		t.Fatalf("Error should be not connect, got %s", err.Error())

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -49,7 +49,7 @@ func TestShortMessage(t *testing.T) {
 		Dst:      "foobar",
 		Text:     pdutext.Raw("Lorem ipsum"),
 		Validity: 10 * time.Minute,
-		Register: NoDeliveryReceipt,
+		Register: pdufield.NoDeliveryReceipt,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +105,7 @@ func TestShortMessageWindowSize(t *testing.T) {
 			Dst:      "foobar",
 			Text:     pdutext.Raw("Lorem ipsum"),
 			Validity: 10 * time.Minute,
-			Register: NoDeliveryReceipt,
+			Register: pdufield.NoDeliveryReceipt,
 		}
 	}
 	nerr := 0
@@ -151,7 +151,7 @@ func TestLongMessage(t *testing.T) {
 		Dst:      "foobar",
 		Text:     pdutext.Raw("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam consequat nisl enim, vel finibus neque aliquet sit amet. Interdum et malesuada fames ac ante ipsum primis in faucibus."),
 		Validity: 10 * time.Minute,
-		Register: NoDeliveryReceipt,
+		Register: pdufield.NoDeliveryReceipt,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/time/rate"
+	"golang.org/x/time/rate"
 
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/time/rate"
+
 	"github.com/fiorix/go-smpp/smpp/pdu"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
 	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
@@ -30,9 +32,10 @@ func TestShortMessage(t *testing.T) {
 	s.Start()
 	defer s.Close()
 	tx := &Transmitter{
-		Addr:   s.Addr(),
-		User:   smpptest.DefaultUser,
-		Passwd: smpptest.DefaultPasswd,
+		Addr:        s.Addr(),
+		User:        smpptest.DefaultUser,
+		Passwd:      smpptest.DefaultPasswd,
+		RateLimiter: rate.NewLimiter(rate.Limit(10), 1),
 	}
 	defer tx.Close()
 	conn := <-tx.Bind()


### PR DESCRIPTION
1. RateLimiter from dev tree
2. Fixed QuerySM "0" status according to SMPP 5.0 specs (props to @blind-oracle)
3. Use BindInterval delay (if given) for retry in Bind() instead of exponential growth (props to @blind-oracle)
4. Implemented EnquireLinkResp as time of the last response in enquireLink function:
- if we don't get the response from server within the time window, unbind and close the connection (according to specs, enquirelink serves as "confidence-check of the communication path between an ESME and an SMSC", so if there's no response, we can't be confident that our connection is alive)
5. Added src TON/NPI to QuerySM (props to @blind-oracle)
6. Added EnquireLinkTimeout (props to @blind-oracle)
7. Renamed conn to cl as it holds the client, not the connection
8. Added sending of DeliverSMResp to receiver (props to @blind-oracle)
- this fixes the problem when we're not responding to the receiver gate and it stops the connection from the server side
9. Merged pull request https://github.com/fiorix/go-smpp/pull/28