### PR TITLE
Use two byte reference number when submitting long messages

### DIFF
--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -327,21 +327,25 @@ func (t *Transmitter) Submit(sm *ShortMessage) (*ShortMessage, error) {
 // and returns and updates the given sm with the response status.
 // It returns the same sm object.
 func (t *Transmitter) SubmitLongMsg(sm *ShortMessage) (*ShortMessage, error) {
-	maxLen := 134 // 140-6 (UDH)
+	maxLen := 133 // 140-7 (UDH with 2 byte reference number)
+	if sm.Text.Type() == pdutext.UCS2Type {
+		maxLen = 132 // to avoid a character being split between payloads
+	}
 	rawMsg := sm.Text.Encode()
 	countParts := int((len(rawMsg)-1)/maxLen) + 1
 
 	t.rMutex.Lock()
-	ri := uint8(t.r.Intn(128))
+	rn := uint16(t.r.Intn(65535))
 	t.rMutex.Unlock()
-	UDHHeader := make([]byte, 6)
-	UDHHeader[0] = 5
-	UDHHeader[1] = 0
-	UDHHeader[2] = 3
-	UDHHeader[3] = ri
-	UDHHeader[4] = uint8(countParts)
+	UDHHeader := make([]byte, 7)
+	UDHHeader[0] = 0x06              // length of user data header
+	UDHHeader[1] = 0x08              // information element identifier, CSMS 16 bit reference number
+	UDHHeader[2] = 0x04              // length of remaining header
+	UDHHeader[3] = uint8(rn >> 8)    // most significant byte of the reference number
+	UDHHeader[4] = uint8(rn)         // least significant byte of the reference number
+	UDHHeader[5] = uint8(countParts) // total number of message parts
 	for i := 0; i < countParts; i++ {
-		UDHHeader[5] = uint8(i + 1)
+		UDHHeader[6] = uint8(i + 1) // current message part
 		p := pdu.NewSubmitSM()
 		f := p.Fields()
 		f.Set(pdufield.SourceAddr, sm.Src)

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -335,7 +335,7 @@ func (t *Transmitter) SubmitLongMsg(sm *ShortMessage) (*ShortMessage, error) {
 	countParts := int((len(rawMsg)-1)/maxLen) + 1
 
 	t.rMutex.Lock()
-	rn := uint16(t.r.Intn(65535))
+	rn := uint16(t.r.Intn(0xFFFF))
 	t.rMutex.Unlock()
 	UDHHeader := make([]byte, 7)
 	UDHHeader[0] = 0x06              // length of user data header

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -165,6 +165,68 @@ func TestLongMessage(t *testing.T) {
 	}
 }
 
+func TestLongMessageAsUCS2(t *testing.T) {
+	s := smpptest.NewUnstartedServer()
+	var receivedMsg string
+	shortMsg := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam consequat nisl enim, vel finibus neque aliquet sit amet. Interdum et malesuada fames ac ante ipsum primis in faucibus. ✓"
+	s.Handler = func(c smpptest.Conn, p pdu.Body) {
+		switch p.Header().ID {
+		case pdu.SubmitSMID:
+			r := pdu.NewSubmitSMResp()
+			r.Header().Seq = p.Header().Seq
+			r.Fields().Set(pdufield.MessageID, "foobar")
+			smByts := p.Fields()[pdufield.ShortMessage].Bytes()
+			switch pdutext.DataCoding(p.Fields()[pdufield.DataCoding].Raw().(uint8)) {
+			case pdutext.Latin1Type:
+				receivedMsg = receivedMsg + string(pdutext.Latin1(smByts)[7:].Decode())
+			case pdutext.UCS2Type:
+				receivedMsg = receivedMsg + string(pdutext.UCS2(smByts)[7:].Decode())
+			default:
+				receivedMsg = receivedMsg + string(smByts[7:])
+			}
+			c.Write(r)
+		default:
+			smpptest.EchoHandler(c, p)
+		}
+	}
+	s.Start()
+	defer s.Close()
+	tx := &Transmitter{
+		Addr:   s.Addr(),
+		User:   smpptest.DefaultUser,
+		Passwd: smpptest.DefaultPasswd,
+	}
+	defer tx.Close()
+	conn := <-tx.Bind()
+	switch conn.Status() {
+	case Connected:
+	default:
+		t.Fatal(conn.Error())
+	}
+	sm, err := tx.SubmitLongMsg(&ShortMessage{
+		Src:      "root",
+		Dst:      "foobar",
+		Text:     pdutext.UCS2(shortMsg),
+		Validity: 10 * time.Minute,
+		Register: pdufield.NoDeliveryReceipt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgid := sm.RespID()
+	if msgid == "" {
+		t.Fatalf("pdu does not contain msgid: %#v", sm.Resp())
+	}
+
+	if receivedMsg != shortMsg {
+		t.Fatalf("receivedMsg: %v, does not match shortMsg: %v", receivedMsg, shortMsg)
+	}
+
+	if msgid != "foobar" {
+		t.Fatalf("unexpected msgid: want foobar, have %q", msgid)
+	}
+}
+
 func TestQuerySM(t *testing.T) {
 	s := smpptest.NewUnstartedServer()
 	s.Handler = func(c smpptest.Conn, p pdu.Body) {


### PR DESCRIPTION
to fix #45 