### PR TITLE
Fix panic under race condition (send on closed channel)

### DIFF
--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -288,7 +288,6 @@ func (t *Transmitter) do(p pdu.Body) (*tx, error) {
 	t.tx.inflight[seq] = rc
 	t.tx.Unlock()
 	defer func() {
-		close(rc)
 		t.tx.Lock()
 		delete(t.tx.inflight, seq)
 		t.tx.Unlock()


### PR DESCRIPTION
There's a race condition that usually happens under high load when the response time of SMPP server is equal to the go-smpp timeout.

When the SubmitSM is sent, go-smpp waits for SubmitSMResp for RespTimeout duration.

If the SubmitSMResp comes in the exact moment t.cl.respTimeout() kicks in, then the channel in t.tx.inflight is already closed, but HandlePDU already got the channel from this map in parallel and tries to send SubmitSMResp there. And here we get "panic: send on closed channel".

Let's just skip the channel close and let HandlePDU write there and then, after the channel entry is deleted from the t.tx.inflight map, the channel will be garbage collected.