### PR TITLE
Create inflight key based on ID and Seq to avoid conflicting Seq

### DIFF
--- a/smpp/pdu/header.go
+++ b/smpp/pdu/header.go
@@ -53,6 +53,14 @@ func (id ID) String() string {
 	return idString[id]
 }
 
+// Group returns group of a given ID.
+// Example: SubmitSM, SubmitSMResp should return the same group: 0x04.
+func (id ID) Group() uint16 {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(id))
+	return binary.BigEndian.Uint16(b[2:4])
+}
+
 // HeaderLen is the PDU header length.
 const HeaderLen = 16
 
@@ -62,6 +70,11 @@ type Header struct {
 	ID     ID
 	Status Status
 	Seq    uint32 // Sequence number.
+}
+
+// Key return key of a given header based on ID and Seq
+func (h *Header) Key() string {
+	return fmt.Sprintf("%o-%d", h.ID.Group(), h.Seq)
 }
 
 // DecodeHeader decodes binary PDU header data.

--- a/smpp/pdu/header_test.go
+++ b/smpp/pdu/header_test.go
@@ -73,3 +73,64 @@ func TestDecodeHeader(t *testing.T) {
 		t.Fatalf("unexpected parsing of big Len: %#v", h)
 	}
 }
+
+func TestGroup(t *testing.T) {
+	testCases := []struct {
+		id    ID
+		group uint16
+	}{
+		{GenericNACKID, 0x00},
+		{BindReceiverID, 0x01},
+		{BindReceiverRespID, 0x01},
+		{BindTransmitterID, 0x02},
+		{BindTransmitterRespID, 0x02},
+		{QuerySMID, 0x03},
+		{QuerySMRespID, 0x03},
+		{SubmitSMID, 0x0004},
+		{SubmitSMRespID, 0x0004},
+		{DeliverSMID, 0x05},
+		{DeliverSMRespID, 0x05},
+		{UnbindID, 0x06},
+		{UnbindRespID, 0x06},
+		{ReplaceSMID, 0x07},
+		{ReplaceSMRespID, 0x07},
+		{CancelSMID, 0x08},
+		{CancelSMRespID, 0x08},
+		{BindTransceiverID, 0x09},
+		{BindTransceiverRespID, 0x09},
+		{OutbindID, 0x0B},
+		{EnquireLinkID, 0x15},
+		{EnquireLinkRespID, 0x15},
+		{SubmitMultiID, 0x21},
+		{SubmitMultiRespID, 0x21},
+		{AlertNotificationID, 0x102},
+		{DataSMID, 0x103},
+		{DataSMRespID, 0x103},
+	}
+
+	for _, tc := range testCases {
+		group := tc.id.Group()
+		if group != tc.group {
+			t.Fatalf("expected: %o, actual: %o", tc.group, group)
+		}
+	}
+}
+
+func TestKey(t *testing.T) {
+	sm := []byte{
+		0x00, 0x00, 0x00, 0x10, // 16 Len
+		0x00, 0x00, 0x00, 0x04, // SubmitSMID
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	smH, err := DecodeHeader(bytes.NewBuffer(sm))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k := smH.Key()
+	if k != "4-0" {
+		t.Fatalf("unexpected key: %s", k)
+	}
+}

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -43,7 +43,7 @@ func (t *Transceiver) Bind() <-chan ConnStatus {
 		return t.cl.Status
 	}
 	t.tx.Lock()
-	t.tx.inflight = make(map[uint32]chan *tx)
+	t.tx.inflight = make(map[string]chan *tx)
 	t.tx.Unlock()
 	c := &client{
 		Addr:               t.Addr,

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -53,7 +53,7 @@ type Transmitter struct {
 	tx struct {
 		count int32
 		sync.Mutex
-		inflight map[uint32]chan *tx
+		inflight map[string]chan *tx
 	}
 }
 
@@ -74,7 +74,7 @@ func (t *Transmitter) Bind() <-chan ConnStatus {
 		return t.cl.Status
 	}
 	t.tx.Lock()
-	t.tx.inflight = make(map[uint32]chan *tx)
+	t.tx.inflight = make(map[string]chan *tx)
 	t.tx.Unlock()
 	c := &client{
 		Addr:               t.Addr,
@@ -119,9 +119,9 @@ func (t *Transmitter) handlePDU(f HandlerFunc) {
 		if err != nil {
 			break
 		}
-		seq := p.Header().Seq
+		key := p.Header().Key()
 		t.tx.Lock()
-		rc := t.tx.inflight[seq]
+		rc := t.tx.inflight[key]
 		t.tx.Unlock()
 		if rc != nil {
 			rc <- &tx{PDU: p}
@@ -182,7 +182,7 @@ type ShortMessage struct {
 	Register pdufield.DeliverySetting
 
 	// Other fields, normally optional.
-	TLVFields			 pdutlv.Fields
+	TLVFields            pdutlv.Fields
 	ServiceType          string
 	SourceAddrTON        uint8
 	SourceAddrNPI        uint8
@@ -285,13 +285,13 @@ func (t *Transmitter) do(p pdu.Body) (*tx, error) {
 		}
 	}
 	rc := make(chan *tx, 1)
-	seq := p.Header().Seq
+	key := p.Header().Key()
 	t.tx.Lock()
-	t.tx.inflight[seq] = rc
+	t.tx.inflight[key] = rc
 	t.tx.Unlock()
 	defer func() {
 		t.tx.Lock()
-		delete(t.tx.inflight, seq)
+		delete(t.tx.inflight, key)
 		t.tx.Unlock()
 	}()
 	err := t.cl.Write(p)


### PR DESCRIPTION
We are using Seq to distinguish the request/response channel. But the Seq of Submit and Deliver may be the same. So it may causes issue 'unexpected PDU ID'.

My scenario:

 - Client sends SubmitSM and wait for SubmitSMResp
 - At the same time, server sends DeliverSM with the same Seq
 - Then error 'unexpected PDU ID' 

My solution:
The key should be combined of Seq and an id of (SubmitSM, SubmitSMResp) round trip. 
I see that the last 2 bytes of ID is potential candidate for that id. 


