### PR TITLE
close and recreate client.inbox channel after disconnected fixes #79

### DIFF
--- a/smpp/client.go
+++ b/smpp/client.go
@@ -105,7 +105,6 @@ type client struct {
 }
 
 func (c *client) init() {
-	c.inbox = make(chan pdu.Body)
 	c.conn = &connSwitch{}
 	c.stop = make(chan struct{})
 	if c.RateLimiter != nil {
@@ -127,6 +126,7 @@ func (c *client) Bind() {
 	const maxdelay = 120.0
 	for !c.closed() {
 		eli := make(chan struct{})
+		c.inbox = make(chan pdu.Body)
 		conn, err := Dial(c.Addr, c.TLS)
 		if err != nil {
 			c.notify(&connStatus{
@@ -168,6 +168,7 @@ func (c *client) Bind() {
 	retry:
 		close(eli)
 		c.conn.Close()
+		close(c.inbox)
 		delayDuration := c.BindInterval
 		if delayDuration == 0 {
 			delay = math.Min(delay*math.E, maxdelay)

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -116,7 +116,7 @@ func (t *Transmitter) bindFunc(c Conn) error {
 func (t *Transmitter) handlePDU(f HandlerFunc) {
 	for {
 		p, err := t.cl.Read()
-		if err != nil {
+		if err != nil || p == nil {
 			break
 		}
 		seq := p.Header().Seq


### PR DESCRIPTION
Initialize client.inbox channel lazily and close it once Disconnected in order to release bindFunc goroutines waiting on the channel.