### PR TITLE
feat: DeliverSMResp on Receiver

### DIFF
--- a/smpp/receiver.go
+++ b/smpp/receiver.go
@@ -241,6 +241,14 @@ loop:
 	}
 }
 
+// DeliverSMResp will send a DeliverSMResp. It can be used
+// to manually send a DeliverSMResp when you have configured
+// the receiver to not autorespond to all DeliverSM received
+func (r *Receiver) DeliverSMResp(seq uint32) error {
+	pResp := pdu.NewDeliverSMRespSeq(seq)
+	return r.cl.Write(pResp)
+}
+
 func (r *Receiver) mergeCleaner() {
 	timer := time.NewTimer(r.MergeCleanupInterval)
 


### PR DESCRIPTION
## Reason
I'm polling for DeliverSM and have disabled the auto-respond functionality with the aim of only marking the receipt of the message after successfully sinking the message to our pipeline, this is so the carrier will attempt to redeliver the message in the event of some issue. However I can not find a graceful way of manually doing this without getting to hacky.
## Goal  
Expose a DeliverSMResp function on the Receiver that can be used in conjunction with the disable auto-respond functionality