### PR TITLE
handle pdu if nil returned

### DIFF
--- a/smpp/receiver.go
+++ b/smpp/receiver.go
@@ -162,6 +162,10 @@ loop:
 			break
 		}
 
+		if p == nil {
+			break
+		}
+
 		if p.Header().ID == pdu.DeliverSMID && autoRespondDeliver { // Send DeliverSMResp
 			pResp := pdu.NewDeliverSMRespSeq(p.Header().Seq)
 			r.cl.Write(pResp)


### PR DESCRIPTION
In some cases [1] r.cl.Read() returns a nil interface without any errors, leading to panics when the p.Header() (when p == nil) is called.

This change adds a simple check for nil values.

Example:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x5c5389]

goroutine 7 [running]:
redacted/vendor/github.com/fiorix/go-smpp/smpp.(*Receiver).handlePDU(0xc0000ec180)
        /home/yekta/.go/src/redacted/vendor/github.com/fiorix/go-smpp/smpp/receiver.go:176 +0x1f9
created by redacted/vendor/github.com/fiorix/go-smpp/smpp.(*Receiver).bindFunc
        /home/yekta/.go/src/redacted/vendor/github.com/fiorix/go-smpp/smpp/receiver.go:132 +0x344
exit status 2
```

[1] For example, when the connection is abruptly closed by the server.