### PR TITLE
use /v2 for local package imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ transformation for LATIN-1 and UCS-2.
 
 It is not fully compliant, there are some TODOs in the code.
 
+Be sure to use `import "/github.com/fiorix/go-smpp/v2"`.
+
 ## Usage
 
 Following is an SMPP client transmitter wrapped by an HTTP server

--- a/cmd/sms/main.go
+++ b/cmd/sms/main.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/urfave/cli"
 
-	"github.com/fiorix/go-smpp/smpp"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
 )
 
 // Version of smppcli.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/fiorix/go-smpp/v2
 go 1.15
 
 require (
-	github.com/fiorix/go-smpp v0.0.0-20210403173735-2894b96e70ba
 	github.com/urfave/cli v1.22.5
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/fiorix/go-smpp v0.0.0-20210403173735-2894b96e70ba h1:vBqABUa2HUSc6tj22Tw+ZMVGHuBzKtljM38kbRanmrM=
-github.com/fiorix/go-smpp v0.0.0-20210403173735-2894b96e70ba/go.mod h1:VfKFK7fGeCP81xEhbrOqUEh45n73Yy6jaPWwTVbxprI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/smpp/client.go
+++ b/smpp/client.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
 )
 
 // ConnStatus is an abstract interface for a connection status change.

--- a/smpp/conn.go
+++ b/smpp/conn.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
 )
 
 var (

--- a/smpp/conn_test.go
+++ b/smpp/conn_test.go
@@ -7,9 +7,9 @@ package smpp
 import (
 	"testing"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/smpptest"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/smpptest"
 )
 
 func TestConn(t *testing.T) {

--- a/smpp/example_test.go
+++ b/smpp/example_test.go
@@ -12,10 +12,10 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"github.com/fiorix/go-smpp/smpp"
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
 )
 
 func ExampleReceiver() {

--- a/smpp/pdu/body.go
+++ b/smpp/pdu/body.go
@@ -7,8 +7,8 @@ package pdu
 import (
 	"io"
 
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutlv"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutlv"
 )
 
 // MaxSize is the maximum size allowed for a PDU.

--- a/smpp/pdu/codec.go
+++ b/smpp/pdu/codec.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"sync/atomic"
 
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutlv"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutlv"
 )
 
 var nextSeq uint32

--- a/smpp/pdu/pdufield/map.go
+++ b/smpp/pdu/pdufield/map.go
@@ -7,7 +7,7 @@ package pdufield
 import (
 	"fmt"
 
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
 )
 
 // Map is a collection of PDU field data indexed by name.

--- a/smpp/pdu/pdufield/map_test.go
+++ b/smpp/pdu/pdufield/map_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
 )
 
 func TestMapSet(t *testing.T) {

--- a/smpp/pdu/pdutext/gsm7.go
+++ b/smpp/pdu/pdutext/gsm7.go
@@ -5,8 +5,9 @@
 package pdutext
 
 import (
-    "golang.org/x/text/transform"
-    "github.com/fiorix/go-smpp/smpp/encoding"
+	"github.com/fiorix/go-smpp/v2/smpp/encoding"
+
+	"golang.org/x/text/transform"
 )
 
 // GSM 7-bit (unpacked)

--- a/smpp/pdu/pdutext/gsm7packed.go
+++ b/smpp/pdu/pdutext/gsm7packed.go
@@ -5,8 +5,9 @@
 package pdutext
 
 import (
-    "golang.org/x/text/transform"
-    "github.com/fiorix/go-smpp/smpp/encoding"
+	"github.com/fiorix/go-smpp/v2/smpp/encoding"
+
+	"golang.org/x/text/transform"
 )
 
 // GSM 7-bit (packed)

--- a/smpp/pdu/types.go
+++ b/smpp/pdu/types.go
@@ -5,8 +5,8 @@
 package pdu
 
 import (
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutlv"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutlv"
 )
 
 // PDU Types.

--- a/smpp/pdu/types_test.go
+++ b/smpp/pdu/types_test.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
 )
 
 func TestBind(t *testing.T) {

--- a/smpp/receiver.go
+++ b/smpp/receiver.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
 )
 
 // Receiver implements an SMPP client receiver.

--- a/smpp/receiver_test.go
+++ b/smpp/receiver_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/smpptest"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/smpptest"
 )
 
 func TestReceiver(t *testing.T) {

--- a/smpp/smpptest/conn.go
+++ b/smpp/smpptest/conn.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"net"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
 )
 
 // Conn implements a server side connection.

--- a/smpp/smpptest/server.go
+++ b/smpp/smpptest/server.go
@@ -13,8 +13,8 @@ import (
 	"net"
 	"sync"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
 )
 
 // Default settings.

--- a/smpp/smpptest/server_test.go
+++ b/smpp/smpptest/server_test.go
@@ -9,10 +9,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutlv"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutlv"
 )
 
 func TestServer(t *testing.T) {

--- a/smpp/transceiver.go
+++ b/smpp/transceiver.go
@@ -10,8 +10,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
 )
 
 // Transceiver implements an SMPP transceiver.

--- a/smpp/transceiver_test.go
+++ b/smpp/transceiver_test.go
@@ -11,10 +11,10 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
-	"github.com/fiorix/go-smpp/smpp/smpptest"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/smpptest"
 )
 
 func TestTransceiver(t *testing.T) {

--- a/smpp/transmitter.go
+++ b/smpp/transmitter.go
@@ -15,10 +15,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutlv"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutlv"
 )
 
 // ErrMaxWindowSize is returned when an operation (such as Submit) violates

--- a/smpp/transmitter_test.go
+++ b/smpp/transmitter_test.go
@@ -11,10 +11,10 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"github.com/fiorix/go-smpp/smpp/pdu"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdufield"
-	"github.com/fiorix/go-smpp/smpp/pdu/pdutext"
-	"github.com/fiorix/go-smpp/smpp/smpptest"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdufield"
+	"github.com/fiorix/go-smpp/v2/smpp/pdu/pdutext"
+	"github.com/fiorix/go-smpp/v2/smpp/smpptest"
 )
 
 func TestShortMessage(t *testing.T) {


### PR DESCRIPTION
This was changed in fe1b3c72362b03d9fd3afb7541a95e48218fe3e6.

I don't know why it was called /v2, but if it is then the local imports should refer to the same version.