### PR TITLE
[encoding/gsm7] Fix the bug of confusion with '@' when the first 7 bi…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/fiorix/go-smpp v0.0.0-20210403173735-2894b96e70ba h1:vBqABUa2HUSc6tj22Tw+ZMVGHuBzKtljM38kbRanmrM=
 github.com/fiorix/go-smpp v0.0.0-20210403173735-2894b96e70ba/go.mod h1:VfKFK7fGeCP81xEhbrOqUEh45n73Yy6jaPWwTVbxprI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/smpp/encoding/gsm7.go
+++ b/smpp/encoding/gsm7.go
@@ -209,6 +209,10 @@ func (g *gsm7Decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, er
 		}
 	}
 
+	if g.packed && len(septets)%8 == 0 && septets[len(septets)-1] == 0x0d {
+		septets = septets[:len(septets)-1]
+	}
+
 	nSeptet := 0
 	builder := bytes.NewBufferString("")
 	for nSeptet < len(septets) {
@@ -271,6 +275,7 @@ func (g *gsm7Encoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, er
 	}
 
 	nDst = len(septets)
+	unpackedLen := nDst
 	if g.packed {
 		nDst = int(math.Ceil(float64(len(septets)) * 7 / 8))
 	}
@@ -354,5 +359,14 @@ func (g *gsm7Encoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, er
 		}
 		remain = len(septets) - nSeptet
 	}
+
+	// When there are 7 spare bits in the last octet of a message, these bits are set to the 7-bit code of the CR control
+	// (also used as a padding filler) instead of being set to zero (where they would be confused with the 7-bit code of an '@' character).
+	if g.packed && (unpackedLen*7)%8 == 1 {
+		if v := dst[nDst-1]; v == 0x01 || v == 0x00 {
+			dst[nDst-1] = v | 0x0d<<1
+		}
+	}
+
 	return nDst, nSrc, err
 }


### PR DESCRIPTION
Fix the bug of confusion with '@' when the first 7 bits of the last byte after GSM7(Packed) pack are all 0.

Change-Id: I87dca3d5b1b21c1d722e630b8cb5228c57d5084e