### PR TITLE
pdutlv: encode uint16/uint32 TLVs; pdu: clamp sequence_number to spec range

### DIFF
--- a/smpp/pdu/codec.go
+++ b/smpp/pdu/codec.go
@@ -34,7 +34,14 @@ func (pdu *codec) init() {
 	pdu.f = make(pdufield.Map)
 	pdu.t = make(pdutlv.Map)
 	if pdu.h.Seq == 0 { // If Seq not set
-		pdu.h.Seq = atomic.AddUint32(&nextSeq, 1)
+		// SMPP 3.4 §5.1.4 restricts sequence_number to 0x00000001..0x7FFFFFFF.
+		// Wrap within that range (skipping 0) so a long-lived connection never
+		// emits a value strict SMSCs would reject as an invalid header.
+		next := atomic.AddUint32(&nextSeq, 1) & 0x7FFFFFFF
+		if next == 0 {
+			next = atomic.AddUint32(&nextSeq, 1) & 0x7FFFFFFF
+		}
+		pdu.h.Seq = next
 	}
 }
 

--- a/smpp/pdu/codec_seq_test.go
+++ b/smpp/pdu/codec_seq_test.go
@@ -1,0 +1,24 @@
+// Copyright 2015 go-smpp authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package pdu
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// Sequence numbers must stay within SMPP 3.4 §5.1.4's 1..0x7FFFFFFF range,
+// including across the wrap at 0x7FFFFFFF.
+func TestSequenceNumber_StaysInSpecRange(t *testing.T) {
+	// Drive the counter across the 0x7FFFFFFF boundary.
+	atomic.StoreUint32(&nextSeq, 0x7FFFFFFE)
+	for i := 0; i < 5; i++ {
+		c := &codec{h: &Header{}}
+		c.init()
+		if c.h.Seq == 0 || c.h.Seq > 0x7FFFFFFF {
+			t.Fatalf("seq %#x out of range 1..0x7FFFFFFF", c.h.Seq)
+		}
+	}
+}

--- a/smpp/pdu/pdutlv/tlv_map.go
+++ b/smpp/pdu/pdutlv/tlv_map.go
@@ -5,6 +5,7 @@
 package pdutlv
 
 import (
+	"encoding/binary"
 	"fmt"
 )
 
@@ -21,7 +22,20 @@ func (m Map) Set(t Tag, v interface{}) error {
 		m[t] = NewTLV(t, nil) // use default value
 	case uint8:
 		m[t] = NewTLV(t, []byte{v.(uint8)})
+	case uint16:
+		// 2-octet Integer TLV (e.g. sar_msg_ref_num), big-endian per SMPP 3.4.
+		b := make([]byte, 2)
+		binary.BigEndian.PutUint16(b, v.(uint16))
+		m[t] = NewTLV(t, b)
+	case uint32:
+		// 4-octet Integer TLV, big-endian per SMPP 3.4.
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b, v.(uint32))
+		m[t] = NewTLV(t, b)
 	case int:
+		// Backward-compatible: int is encoded as a single octet. Callers that
+		// need a 2- or 4-octet integer TLV must pass a uint16/uint32 (above);
+		// an int value >255 would otherwise be silently truncated here.
 		m[t] = NewTLV(t, []byte{uint8(v.(int))})
 	case string:
 		m[t] = NewTLV(t, []byte(v.(string)))

--- a/smpp/pdu/pdutlv/tlv_map_int_test.go
+++ b/smpp/pdu/pdutlv/tlv_map_int_test.go
@@ -1,0 +1,29 @@
+// Copyright 2015 go-smpp authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package pdutlv
+
+import (
+	"bytes"
+	"testing"
+)
+
+// uint16 and uint32 values must encode as big-endian multi-octet TLVs, not be
+// dropped (the previous Map.Set had no case for them and returned an error).
+func TestMapSet_Uint16And32(t *testing.T) {
+	m := Map{}
+	if err := m.Set(TagSarMsgRefNum, uint16(0x1234)); err != nil {
+		t.Fatalf("Set uint16: %v", err)
+	}
+	if got := m[TagSarMsgRefNum].Bytes(); !bytes.Equal(got, []byte{0x12, 0x34}) {
+		t.Fatalf("uint16 TLV = % X; want 12 34", got)
+	}
+
+	if err := m.Set(TagQosTimeToLive, uint32(0x01020304)); err != nil {
+		t.Fatalf("Set uint32: %v", err)
+	}
+	if got := m[TagQosTimeToLive].Bytes(); !bytes.Equal(got, []byte{0x01, 0x02, 0x03, 0x04}) {
+		t.Fatalf("uint32 TLV = % X; want 01 02 03 04", got)
+	}
+}


### PR DESCRIPTION
Two small, self-contained fixes, each with a test, on top of current `main`:

1. **`pdutlv`: encode `uint16`/`uint32` TLV values.** `Map.Set` handles `uint8`, `int` (single octet), `string`, and `[]byte`, so a 2-octet Integer TLV such as `sar_msg_ref_num` (0x020C) passed as a `uint16` hits the `default` case and returns an error — and because `NewSubmitSM`/`NewDataSM` discard `Set`'s error, the TLV is silently dropped from the wire. This adds `uint16` (2 big-endian octets) and `uint32` (4 octets) cases. `case int` is left as-is (single octet) for backward compatibility, with a note directing callers to the typed cases.

2. **`pdu`: keep `sequence_number` within `1..0x7FFFFFFF`.** The auto-assigned sequence number counts the full `uint32` space, so a long-lived connection eventually emits values above `0x7FFFFFFF`, which SMPP 3.4 §5.1.4 disallows and strict SMSCs may reject. This masks the counter to 31 bits, skipping 0 on wrap.

`main` builds and the full suite passes with these applied.

(For context: two related fixes I'd initially prepared — `data_sm`/`data_sm_resp` codecs and replying `unbind_resp` to a peer-initiated unbind — turned out to already be on `main`, so they're omitted here.)
